### PR TITLE
Fix notice and warning from an empty hotspots field

### DIFF
--- a/hotspots.module
+++ b/hotspots.module
@@ -18,7 +18,7 @@ function hotspots_entity_view($entity, $type, $view_mode, $langcode) {
       continue;
     }
 
-    if (isset($entity->{$field_name})) {
+    if (!empty($entity->{$field_name})) {
       foreach ($entity->{$field_name}[LANGUAGE_NONE] as $delta => $field) {
         if (isset($field['associate_image_field']) && isset($field['associate_image_delta'])) {
           $id = hotspots_id($field['associate_image_field'], $field['associate_image_delta']);


### PR DESCRIPTION
When the hotspots field is empty, it becomes an empty array and passes the `isset` check. The patch changes that to use `!empty` which detects for empty array as well.
<img width="566" alt="nbc - parenthood retrospective 2015-07-16 11-32-33" src="https://cloud.githubusercontent.com/assets/448830/8727552/5e1f24ca-2bae-11e5-9c4b-a099e4847545.png">
<img width="504" alt="www 2015-07-16 10-52-10" src="https://cloud.githubusercontent.com/assets/448830/8727517/29d0a02c-2bae-11e5-9dd9-c2aec418dc0f.png">
